### PR TITLE
Fix BLEDevice import

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -7,9 +7,10 @@ from typing import Any
 
 import voluptuous as vol
 
+from bleak.backends.device import BLEDevice
+
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.components.bluetooth.wrappers import BLEDevice
 from homeassistant.config_entries import ConfigFlow, FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import (

--- a/sensor.py
+++ b/sensor.py
@@ -3,7 +3,6 @@
 import logging
 from math import ceil
 
-from homeassistant.components.bluetooth.wrappers import BLEDevice
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,


### PR DESCRIPTION
With HA 2024.1 the wrappers module has disappeared. This fixes that.